### PR TITLE
Fix Stopwatch Minute Calculation Issue

### DIFF
--- a/stopwatch/index.js
+++ b/stopwatch/index.js
@@ -109,6 +109,7 @@ const msChanger = () => {
     addtwodigitKeeperMs();
     timePeriodOfMs = 0;
     ms.textContent = timePeriodOfMs;
+    secondChanger()
   } else {
     if (timePeriodOfMs === 9) {
       removetwodigitKeeperMs();
@@ -184,7 +185,6 @@ timelaps.addEventListener("click",(event)=>{
  
 
 playPauseButton.addEventListener("click", () => {
-  var secondInterval = setInterval(secondChanger, 1000);
   var msInterval = setInterval(msChanger, 10);
   playPauseButton.style.display = "none";
   pause.style.display = "revert";
@@ -193,7 +193,6 @@ playPauseButton.addEventListener("click", () => {
   timelaps.style.display = "revert";
 
   pause.addEventListener("click", () => {
-    clearInterval(secondInterval);
     clearInterval(msInterval);
 
     var blinkout = setInterval(blinkrevert, 500);
@@ -229,7 +228,6 @@ playPauseButton.addEventListener("click", () => {
     ms.textContent = timePeriodOfMs;
     playPauseButton.style.display = "revert";
     pause.style.display = "none";
-    clearInterval(secondInterval);
     clearInterval(msInterval);
     addtwodigitKeeperMs();
     addtwodigitKeeperS();


### PR DESCRIPTION
• Changes Made:
-Fixed a bug in the stopwatch code related to minute calculation.
-Addressed the issue where frequent clicks on the pause and resume buttons within a second led to incorrect minute values.

• Context:
The stopwatch was exhibiting incorrect minute calculations when users rapidly clicked the pause and resume buttons within a second. This update resolves the bug, ensuring accurate minute increments even with frequent button interactions.

• Testing:
- Thorough testing has been conducted to validate the fix.
- Confirmed that minute values are now accurately calculated, providing a seamless experience for users who frequently interact with the buttons.

• Additional Notes:
- This fix improves the overall reliability of the stopwatch feature.
- Users can now use the stopwatch confidently without worrying about minute calculation inaccuracies, even with rapid button clicks.